### PR TITLE
Correction de l'itération des paquets

### DIFF
--- a/scripts/aur_update
+++ b/scripts/aur_update
@@ -23,9 +23,9 @@ $result =  json_decode(curl_exec($ch), true);
 //var_dump($result);
 
 //Mise à jour table pkg_aur
-$index=0;//index dans $packages
 foreach ($result['results'] as $aur_pkg) {
 	//var_dump($aur_pkg);
+	$index=0;//index dans $packages
 	$name=$aur_pkg['Name'];
 	$version=$aur_pkg['Version'];
 	$found = false;//paquet trouvé dans $packages


### PR DESCRIPTION
Voilà le changement (déjà en prod ;) qui permet d'itérer correctement tous les paquets du dépôt en vue de récupérer leur numéro de versions s'il existe sur AUR.

(pour rappel: https://forums.archlinux.fr/viewtopic.php?f=16&t=16226#p137976 )
